### PR TITLE
Update .NET Core version

### DIFF
--- a/storage-dotnet-circuit-breaker-ha-ra-grs/CircuitBreaker.csproj
+++ b/storage-dotnet-circuit-breaker-ha-ra-grs/CircuitBreaker.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Moving to a [supported .NET version, getting us to December 3, 2022](https://dotnet.microsoft.com/platform/support/policy/dotnet-core).